### PR TITLE
Add grayscale dataset loader and colab instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,22 @@ dataset. To use it:
 2. Run the first cell to install dependencies.
 3. Execute the second cell to start the training loop.
 
-This example works on grayscale images and can be adapted to other black and
-white datasets by editing the configuration file.
+To train on your own grayscale dataset place the images in
+`./data/bwfolder/train` and `./data/bwfolder/test` and use the
+`bwfolder` configuration:
+
+```bash
+!python run.py --config bwfolder --name my_bw_exp --epochs 1 --eval 1 --check 1
+```
+
+After training you can generate images with:
+
+```bash
+!python eval.py --config bwfolder --name my_bw_exp --epochs 1 --eval 1 --generate 64
+```
+
+The provided `bwfolder.yml` configuration simply loads images from an
+`ImageFolder` style directory and performs unconditional generation.
 
 ## Examples
 

--- a/bem/datasets/__init__.py
+++ b/bem/datasets/__init__.py
@@ -90,7 +90,8 @@ image_datasets = [
     "CELEBA_HQ",
     "LSUN",
     "FFHQ",
-    'TINYIMAGENET'
+    'TINYIMAGENET',
+    'BWFOLDER'
 ]
 
 toy_datasets = [
@@ -478,17 +479,35 @@ def get_dataset(p):
 
             )
 
-        dataset = TinyImageNetDataset(root_dir=os.path.join(DATA_PATH, 'tiny-imagenet-200'), 
-                                      mode='train', 
+        dataset = TinyImageNetDataset(root_dir=os.path.join(DATA_PATH, 'tiny-imagenet-200'),
+                                      mode='train',
                                       transform=transform,
                                       download=False,
                                       preload=False)
-        test_dataset = TinyImageNetDataset(root_dir=os.path.join(DATA_PATH, 'tiny-imagenet-200'), 
-                                      mode='test', 
+        test_dataset = TinyImageNetDataset(root_dir=os.path.join(DATA_PATH, 'tiny-imagenet-200'),
+                                      mode='test',
                                       transform=transform,
                                       download=False,
                                       preload=False)
         #train_loader = DataLoader(train_dataset, batch_size=64, shuffle=True)
+    elif config.data.dataset == 'BWFOLDER':
+        bw_path = getattr(config.data, 'path', 'bwfolder')
+        transform_list = [transforms.Resize(config.data.image_size)]
+        if config.data.random_flip:
+            transform_list.append(transforms.RandomHorizontalFlip(p=0.5))
+        transform_list.extend([
+            transforms.ToTensor(),
+            transforms.Lambda(affine_transform)
+        ])
+        transform = transforms.Compose(transform_list)
+        dataset = ImageFolder(
+            root=os.path.join(DATA_PATH, bw_path, 'train'),
+            transform=transform,
+        )
+        test_dataset = ImageFolder(
+            root=os.path.join(DATA_PATH, bw_path, 'test'),
+            transform=transform,
+        )
     else:
         dataset, test_dataset = None, None
 

--- a/dlpm/configs/bwfolder.yml
+++ b/dlpm/configs/bwfolder.yml
@@ -1,0 +1,97 @@
+seed: null
+
+data:
+  dataset: bwfolder
+  path: bwfolder
+  channels: 1
+  image_size: 32 # resize, must be multiple of 32
+  random_flip: true
+
+method: dlpm
+
+dlpm:
+  alpha: 1.8 
+  reverse_steps: 1000
+  isotropic: true
+  mean_predict: EPSILON # See dlpm.ModelMeanType
+  rescale_timesteps: true
+  var_predict: FIXED # see dlpm.ModelVarType
+  scale: 'scale_preserving'
+  input_scaling: false
+
+lim:
+  alpha: 1.8 
+  clamp_a: null
+  clamp_eps: null
+  reverse_steps: 1000
+  isotropic: true
+  rescale_timesteps: true
+  # quadractic_timesteps: false
+
+# replace 'ddim' by 'determinsitic' and udpate dlpm/dlim and lim/ode accordingly
+# manage 'eta'
+eval:
+  data_to_generate: 5000
+  batch_size: 256
+  real_data: 5000 # in case of images, number of real images to store and to compare to
+
+  dlpm:
+    deterministic: false # dlim
+    dlim_eta: 0.0
+    reverse_steps: 1000
+    clip_denoised: false
+    clamp_a: 20
+    clamp_eps: 200
+  
+  lim: 
+    deterministic: false # ODE
+    reverse_steps: 1000
+    clip_denoised: false
+
+model:
+  model_type: "ddpm"
+  attn_resolutions: [2, 4]
+  channel_mult: [1, 2, 2, 2]
+  dropout: 0.0 #0.1
+  model_channels: 32
+  num_heads: 4
+  num_res_blocks: 2
+  learn_variance: false
+
+training:
+  batch_size: 256
+  num_workers: 0
+
+  dlpm:
+    ema_rates:
+    - 0.99
+    grad_clip: null #1.0
+
+    loss_monte_carlo: mean # mean or median. aggregate function to apply to batch loss with M samples of a_{1:T}
+    loss_type: EPS_LOSS # other loss types to reimplment
+    lploss: 2. # p in LP loss. DLPM loss: 2.0, can also try smooth L1 loss (p = 1), or MSE loss (p =-1).
+    monte_carlo_inner: 1 # number of samples for inner expetation approximation in the loss of Proposition (9)
+    monte_carlo_outer: 1 # number of samples for outer expectation approximation in the loss of Proposition (9)
+
+    clamp_a: 20
+    clamp_eps: 200
+
+  lim:
+    ema_rates:
+    - 0.99
+    grad_clip: null #1.0
+
+optim:
+  optimizer: adamw
+  schedule: steplr #steplr
+  lr: 0.0005
+  warmup: 200 #100
+  lr_steps: 300000
+  lr_step_size: 400
+  lr_gamma: 0.99
+
+run:
+  epochs: 900
+  eval_freq: null
+  checkpoint_freq: 300
+  progress: false # print progress bar of iter/epoch


### PR DESCRIPTION
## Summary
- add `bwfolder` config for generic grayscale datasets
- support `BWFOLDER` image dataset via ImageFolder
- document how to train and generate images on custom grayscale datasets in Colab

## Testing
- `python -m py_compile bem/datasets/__init__.py`
