### PR TITLE
Cascade training and grayscale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ When run, the `run_exps.py` file launches experiments for training and sampling 
 
 Once all models have been trained and 30,000 samples have been generated with several number of discretization steps, run `python get_fid.py` to compute FIDs for every setting. If different, you will need to provide the correct path for the training datasets.
 
+### Seismic conditional models
+
+We include helper scripts for grayscale seismic images of size 256x256. The
+training script runs all scales in a cascade and the sampling script generates
+images from the learned cascade.
+
+```
+python scripts/train_cascade.py --data_dir PATH/TO/WAVELET/DATA --j 3
+python scripts/sample_cascade.py --model_root logs/cascade --j 3
+```
+
+Checkpoints are written to `logs/cascade/scale{j}` and samples are saved in the
+same directory after sampling.
+

--- a/improved_diffusion/script_util.py
+++ b/improved_diffusion/script_util.py
@@ -44,6 +44,7 @@ def model_and_diffusion_defaults(task="standard"):
         use_checkpoint=False,
         use_scale_shift_norm=True,
         learn_potential=False,
+        conditioning_channels=3,
     )
 
 
@@ -73,6 +74,7 @@ def create_model_and_diffusion(
     use_checkpoint,
     use_scale_shift_norm,
     learn_potential,
+    conditioning_channels,
 ):
     model = create_model(
         task=task,
@@ -91,6 +93,7 @@ def create_model_and_diffusion(
         use_scale_shift_norm=use_scale_shift_norm,
         dropout=dropout,
         learn_potential=learn_potential,
+        conditioning_channels=conditioning_channels,
     )
     diffusion = create_gaussian_diffusion(
         steps=diffusion_steps,
@@ -123,6 +126,7 @@ def create_model(
     use_scale_shift_norm,
     dropout,
     learn_potential,
+    conditioning_channels,
 ):
     _ = small_size  # hack to prevent unused variable
 
@@ -167,7 +171,7 @@ def create_model(
         learn_potential=learn_potential,
     )
     if task == "wavelet" and conditional:
-        kwargs.update(in_channels=9, conditioning_channels=3)
+        kwargs.update(in_channels=9, conditioning_channels=conditioning_channels)
     kwargs.update(out_channels=kwargs["in_channels"] * (2 if learn_sigma else 1))
 
     return model(**kwargs)

--- a/scripts/sample_cascade.py
+++ b/scripts/sample_cascade.py
@@ -1,0 +1,75 @@
+import argparse, os
+import torch as th
+import numpy as np
+from improved_diffusion import dist_util, logger
+from improved_diffusion.wavelet_datasets import wavelet_to_image, wavelet_stats
+from improved_diffusion.script_util import (
+    model_and_diffusion_defaults,
+    create_model_and_diffusion,
+    args_to_dict,
+    add_dict_to_argparser,
+)
+
+
+def create_argparser():
+    defaults = model_and_diffusion_defaults(task="wavelet")
+    defaults.update(
+        dict(
+            model_root="logs/cascade",
+            j=3,
+            num_samples=1,
+            batch_size=1,
+            wavelet="db4",
+            border_condition="periodization",
+            final_size=256,
+        )
+    )
+    parser = argparse.ArgumentParser()
+    add_dict_to_argparser(parser, defaults)
+    return parser
+
+
+def main():
+    args = create_argparser().parse_args()
+    dist_util.setup_dist()
+    logger.configure()
+
+    models, diffusions, means, stds = [], [], [], []
+    for scale in range(args.j, 0, -1):
+        ckpt = os.path.join(args.model_root, f"scale{scale}", f"model{args.max_training_steps:06d}.pt")
+        model, diffusion = create_model_and_diffusion(
+            task="wavelet",
+            conditioning_channels=args.conditioning_channels,
+            **args_to_dict(args, model_and_diffusion_defaults(task="wavelet").keys(), j=scale),
+        )
+        model.load_state_dict(dist_util.load_state_dict(ckpt, map_location="cpu"))
+        model.to(dist_util.dev())
+        model.eval()
+        models.append(model)
+        diffusions.append(diffusion)
+        mean, std = wavelet_stats(scale, args.model_root)
+        means.append(mean.to(dist_util.dev()))
+        stds.append(std.to(dist_util.dev()))
+
+    low_freq = None
+    for scale in range(args.j, 0, -1):
+        diffusion = diffusions[args.j - scale]
+        model = models[args.j - scale]
+        shape = (args.batch_size, 9 if scale < args.j or args.conditional else 3, args.large_size, args.large_size)
+        sample_fn = diffusion.p_sample_loop
+        model_kwargs = {}
+        if low_freq is not None:
+            model_kwargs["conditional"] = low_freq
+        sample = sample_fn(model, shape, model_kwargs=model_kwargs)
+        if scale > 1:
+            wave = th.cat((sample, low_freq), dim=1) if low_freq is not None else sample
+            wave = wave * stds[args.j - scale][:, None, None] + means[args.j - scale][:, None, None]
+            low_freq = th.from_numpy(wavelet_to_image(wave.cpu().numpy(), args.border_condition, args.wavelet, output_size=args.large_size)).to(dist_util.dev())
+        else:
+            final = (sample + 1) * 127.5
+            arr = final.clamp(0,255).to(th.uint8).permute(0,2,3,1).contiguous()
+            np.savez(os.path.join(args.model_root, "samples.npz"), arr.cpu().numpy())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_cascade.py
+++ b/scripts/train_cascade.py
@@ -1,0 +1,73 @@
+import argparse, os
+from improved_diffusion import dist_util, logger
+from improved_diffusion.script_util import (
+    model_and_diffusion_defaults,
+    create_model_and_diffusion,
+    args_to_dict,
+    add_dict_to_argparser,
+)
+from improved_diffusion.train_util import TrainLoop
+from improved_diffusion.wavelet_datasets import load_data_wavelet
+
+
+def create_argparser():
+    defaults = model_and_diffusion_defaults(task="wavelet")
+    defaults.update(
+        dict(
+            data_dir="",
+            j=3,
+            batch_size=1,
+            log_root="logs/cascade",
+            max_training_steps=50000,
+        )
+    )
+    parser = argparse.ArgumentParser()
+    add_dict_to_argparser(parser, defaults)
+    return parser
+
+
+def main():
+    args = create_argparser().parse_args()
+
+    for scale in range(args.j, 0, -1):
+        dist_util.setup_dist()
+        logdir = os.path.join(args.log_root, f"scale{scale}")
+        logger.configure(dir=logdir)
+        logger.log(f"Training scale {scale}")
+
+        model, diffusion = create_model_and_diffusion(
+            task="wavelet",
+            conditioning_channels=args.conditioning_channels,
+            **args_to_dict(args, model_and_diffusion_defaults(task="wavelet").keys(), j=scale),
+        )
+        model.to(dist_util.dev())
+
+        data = load_data_wavelet(
+            data_dir=args.data_dir,
+            batch_size=args.batch_size,
+            j=scale,
+            conditional=args.conditional,
+        )
+
+        TrainLoop(
+            model=model,
+            diffusion=diffusion,
+            data=data,
+            batch_size=args.batch_size,
+            microbatch=args.microbatch,
+            lr=args.lr,
+            ema_rate=args.ema_rate,
+            log_interval=args.log_interval,
+            save_interval=args.save_interval,
+            resume_checkpoint="",
+            use_fp16=args.use_fp16,
+            fp16_scale_growth=args.fp16_scale_growth,
+            schedule_sampler=diffusion.schedule,
+            weight_decay=args.weight_decay,
+            lr_anneal_steps=args.lr_anneal_steps,
+            max_training_steps=args.max_training_steps,
+        ).run_loop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add fallback stats computation for arbitrary datasets
- ensure grayscale images are handled by converting to RGB
- allow configurable conditioning channels
- add cascade training and sampling scripts
- document seismic usage in README

## Testing
- `python -m py_compile scripts/sample_cascade.py scripts/train_cascade.py improved_diffusion/wavelet_datasets.py improved_diffusion/script_util.py`

------
https://chatgpt.com/codex/tasks/task_e_688969296df08327a226ce918667c4f7