### PR TITLE
Fix singlechannel wavelet imports

### DIFF
--- a/scripts/image_sample.py
+++ b/scripts/image_sample.py
@@ -12,7 +12,11 @@ import torch as th
 import torch.distributed as dist
 
 from improved_diffusion import dist_util, logger
-from improved_diffusion.wavelet_datasets import load_data_wavelet, wavelet_to_image, wavelet_stats
+from improved_diffusion.wavelet_datasets import (
+    load_data_wavelet,
+    wavelet_to_image_singlechannel as wavelet_to_image,
+    wavelet_stats_singlechannel as wavelet_stats,
+)
 from improved_diffusion.script_util import (
     NUM_CLASSES,
     model_and_diffusion_defaults,

--- a/scripts/sample_cascade.py
+++ b/scripts/sample_cascade.py
@@ -2,7 +2,10 @@ import argparse, os
 import torch as th
 import numpy as np
 from improved_diffusion import dist_util, logger
-from improved_diffusion.wavelet_datasets import wavelet_to_image, wavelet_stats
+from improved_diffusion.wavelet_datasets import (
+    wavelet_to_image_singlechannel as wavelet_to_image,
+    wavelet_stats_singlechannel as wavelet_stats,
+)
 from improved_diffusion.script_util import (
     model_and_diffusion_defaults,
     create_model_and_diffusion,


### PR DESCRIPTION
## Summary
- use single channel helper functions in sampling scripts
- keep stats for Haar/DB2 wavelet dataset

## Testing
- `python -m py_compile improved_diffusion/wavelet_datasets.py scripts/image_sample.py scripts/sample_cascade.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898210cad083279c596f5ed0823a11